### PR TITLE
feat: Add confidence score feature

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+PneumoniaAIApp

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,11 +25,20 @@
         android:text="Capture with Camera" />
 
     <TextView
-        android:id="@+id/tvResult"
+        android:id="@+id/tvPrediction"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Prediction: "
+        android:text="Prediction:"
         android:textSize="18sp"
-        android:padding="20dp" />
+        android:padding="10dp" />
+
+    <TextView
+        android:id="@+id/tvConfidence"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Confidence:"
+        android:textSize="16sp"
+        android:padding="10dp" />
+
 
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.1"
+agp = "8.12.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
### Summary
This PR adds a confidence score output to the pneumonia prediction feature, making the results more transparent and user-friendly.

### Changes
- Added a new `runModelAndDisplay()` method that:
  - Validates X-ray input.
  - Runs inference with TensorFlow Lite model.
  - Displays both prediction result and confidence percentage in the UI.
- Updated `onActivityResult()` to use the new method.
- Removed redundant `runModel()` method for cleaner code.
- Added a new TextView (`tvConfidence`) to show confidence score.

### UI Example
Before:
Prediction: Pneumonia

After:
Prediction: Pneumonia
Confidence: 86.72%