### PR TITLE
feat: Add PDF export feature for pneumonia predictions

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+PneumoniaAIApp

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,11 +25,20 @@
         android:text="Capture with Camera" />
 
     <TextView
-        android:id="@+id/tvResult"
+        android:id="@+id/tvPrediction"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Prediction: "
+        android:text="Prediction:"
         android:textSize="18sp"
-        android:padding="20dp" />
+        android:padding="10dp" />
+
+    <TextView
+        android:id="@+id/tvConfidence"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Confidence:"
+        android:textSize="16sp"
+        android:padding="10dp" />
+
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -40,5 +40,13 @@
         android:textSize="16sp"
         android:padding="10dp" />
 
+    <Button
+        android:id="@+id/btnExportReport"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Export Report"
+        android:layout_marginTop="20dp"/>
+
+
 
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.1"
+agp = "8.12.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
### Summary
This PR introduces a new feature to export pneumonia prediction results into a PDF report.  
The report includes:
- Patient's X-ray image
- Predicted result (Pneumonia / Normal)
- Confidence score
- Date and time of prediction

It also supports sharing the generated PDF via other apps.

### Changes
- Added `generatePDFReport()` method to create and save reports in PDF format.
- Added `sharePDF()` method to easily share the saved report.
- Introduced two new fields (`lastPrediction` and `lastConfidence`) to keep track of the latest result for report generation.
- Integrated PDF export functionality after model inference.

### Notes
🚨 **This PR depends on the Confidence Score PR. Please merge that one first before merging this.**